### PR TITLE
ESM / CJS compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "node-gyp": "^9.3.1",
     "npm-run-all": "4.1.5",
     "rxjs": "^7.8.0",
-    "tsup": "6.7.0",
+    "tsup": "^6.7.0",
     "typescript": "5.0.2",
     "vite": "4.2.1",
     "vitest": "0.29.7",
@@ -75,7 +75,8 @@
       "resolve": true
     },
     "splitting": true,
-    "clean": true
+    "clean": true,
+    "shims": true
   },
   "packageManager": "pnpm@7.29.3"
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,6 @@
 import os from 'node:os'
 import path from 'node:path'
+import { URL } from 'url'
 
 /**
  * Ignore diagnostic outputs
@@ -40,5 +41,4 @@ export const redirectingStderrOutput = os.platform() === 'win32' ? '2>&1 > $null
 // eslint-disable-next-line unicorn/escape-case
 export const readSecondInputControlCharacters = ['\u001b', '\n','>']
 
-// eslint-disable-next-line unicorn/prefer-module
-export const defaultBinaryPath = path.join(path.dirname(require.resolve('langchain-alpaca')), 'binary')
+export const defaultBinaryPath = new URL('./binary/', import.meta.url).pathname.substring(1);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "target": "es2020",
     "lib": ["ESNext"],
     "module": "esnext",
     "moduleResolution": "node",


### PR DESCRIPTION
It turns out that the `tsup` utility already used to handle builds in this project already includes the ability to shim the necessary functionality to make this work for both CJS and ESM.

In order to do so easily, I actually swapped the default over to the ESM method that uses `import.meta.url`, as tsup will polyfil in a usable value for CJS users.